### PR TITLE
Update .pre-commit-config.yaml to fix isort bug

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     - id: black
       language_version: python3.10
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)


### PR DESCRIPTION
Minor change to upgrade isort from version 5.11.4 to 5.12.0 to prevent the error documented here: 

https://stackoverflow.com/questions/75269700/pre-commit-fails-to-install-isort-5-11-4-with-error-runtimeerror-the-poetry-co